### PR TITLE
Fixed segfault caused by a

### DIFF
--- a/examples/ls_remote/application.e
+++ b/examples/ls_remote/application.e
@@ -51,9 +51,6 @@ feature -- Intiialize Repository
 
 		do
 			ini := {LIBGIT2_INITIALIZER_API}.git_libgit2_init
-			debug
-				print ("%NIntializing Libgit2")
-			end
 			create repo.make
 
 			if git_repository.git_repository_open (repo, (create {PATH}.make_from_string (path)).out) < 0 then
@@ -85,15 +82,16 @@ feature -- Intiialize Repository
 				-- connect to remote
 			if git_remote.git_remote_connect (l_remote, {GIT_DIRECTION_ENUM_API}.git_direction_fetch, callbacks, Void, Void) < 0 then
 				print ("%NCould not connect to remote repository " + remote)
+				git_remote.git_remote_free (l_remote)
 				{EXCEPTIONS}.die (1)
 			end
-
 			create refs.make (1)
 				-- Get the list of references on the remote and print out
 				-- their name next to what they point to.
 
 			if git_remote.git_remote_ls (refs, l_remote) < 0 then
 				print ("%NCould not get the remote repository's reference advertisement list")
+				git_remote.git_remote_free (l_remote)
 				{EXCEPTIONS}.die (1)
 			end
 
@@ -103,7 +101,7 @@ feature -- Intiialize Repository
 			until
 				refs.after
 			loop
-				create oid.make ({LIBGIT2_CONSTANTS}.GIT_OID_HEXSZ + 1)
+				create oid.make_filled ('%U', {LIBGIT2_CONSTANTS}.GIT_OID_HEXSZ + 1)
 				if attached refs.item_for_iteration.oid as l_oid then
 					git_oid.git_oid_fmt (oid, l_oid)
 					if attached refs.item_for_iteration.name as l_name then
@@ -113,10 +111,8 @@ feature -- Intiialize Repository
 					end
 				end
 				refs.forth
-
 			end
 			git_repository.git_repository_free (repo)
-			git_remote.git_remote_free (l_remote)
 			ini := {LIBGIT2_INITIALIZER_API}.git_libgit2_shutdown
 			io.read_line
 		end
@@ -277,6 +273,7 @@ feature	{NONE} -- Process Arguments
 				#endif
 			]"
 		end
+
 
 feature -- Options
 

--- a/library/generator.sh
+++ b/library/generator.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 #Script to automate WrapC development process.
-wrap_c --verbose --script_pre_process=pre_script.sh --script_post_process=post_script.sh  --output-dir=./generated_wrapper --full-header=./C/include/git2.h --config=config.xml
+wrap_c --verbose --script_pre_process=pre_script.sh --script_post_process=post_script.sh  --output-dir=./generated_wrapper --full-header=/usr/local/include/git2.h --config=config.xml
 

--- a/library/libgit2.ecf
+++ b/library/libgit2.ecf
@@ -27,7 +27,7 @@
 		
 		<!--  Useful when `pkg-config cflags libgit2` does not return the cflags.-->
 	
-		<external_include location="$ECF_CONFIG_PATH/C/include">
+		<external_include location="/usr/local/include">
 			<condition>
 				<platform excluded_value="windows"/>
 			</condition>
@@ -65,14 +65,13 @@
 				<platform excluded_value="windows"/>
 			</condition>
 		</external_object>
-		<!--
+                <!--
 		<external_object location="`pkg-config --libs libgit2`">
 			<condition>
 				<platform excluded_value="windows"/>
 			</condition>
 		</external_object>
-		-->
-
+		-->	
 		<library name="base" location="$ISE_LIBRARY\library\base\base.ecf"/>
 		<cluster name="src" location=".\" recursive="true">
 			<file_rule>

--- a/library/manual_wrapper/git_oid.e
+++ b/library/manual_wrapper/git_oid.e
@@ -27,13 +27,15 @@ feature -- Access
 		end
 
 	git_oid_fmt (a_out: STRING; id: GIT_OID_STRUCT_API)
+			-- Format a git_oid into a hex string.
+--		require
+--			has_null_terminator: a_out.at (a_out.count).is_equal ('%U')
 		local
-			a_out_c_string: C_STRING
 			l_ret: INTEGER
 		do
-			create a_out_c_string.make (a_out)
-			l_ret := c_git_oid_fmt (a_out_c_string.item, id.item)
-			a_out.from_c (a_out_c_string.item)
+			-- TODO if it's ok to add a precondition to this feature
+			--  '\0' terminator must be added by the caller if it is required
+			l_ret := c_git_oid_fmt (a_out.area.base_address, id.item)
 		end
 
 

--- a/library/manual_wrapper/git_remote.e
+++ b/library/manual_wrapper/git_remote.e
@@ -63,19 +63,22 @@ feature -- Access
 		end
 
 	git_remote_ls (a_out: LIST [GIT_REMOTE_HEAD_STRUCT_API]; remote: GIT_REMOTE_STRUCT_API): INTEGER
+			-- Get the remote repository's reference advertisement list.
 		local
 			l_ptr: POINTER
 			l_mgr: MANAGED_POINTER
 			i: INTEGER
-			l_size: INTEGER
+			l_size: INTEGER_64
 			l_item: POINTER
-			l_remote: GIT_REMOTE_HEAD_STRUCT_API
 		do
-			create l_remote.make
-			l_ptr := l_remote.item
 			Result := c_git_remote_ls ($l_ptr, $l_size, remote.item)
-			if l_ptr /= default_pointer then
-				create l_mgr.make_from_pointer (l_ptr, l_size * {PLATFORM}.pointer_bytes)
+			debug
+				print ("%NResult: " +  Result.out)
+				print ("%NSize: " +  l_size.out + "%N")
+			end
+			if Result= 0 and then l_ptr /= default_pointer then
+
+				create l_mgr.make_from_pointer (l_ptr, l_size.to_integer_32 * {PLATFORM}.pointer_bytes)
 				from
 					i := 0
 				until
@@ -87,9 +90,11 @@ feature -- Access
 					end
 					i := i + {PLATFORM}.pointer_bytes
 				end
-
 			end
 		end
+
+
+
 
 
 end


### PR DESCRIPTION
    1. wrong sizeof of the l_size in feature `git_remote_ls` using INTEGER_64 instead of INTEGER_32.
    2. It seems on Linux  '\0' terminator must be added by the caller of the feature git_oid_fmt feature
       that's not needed on Windows.

Fixed the code to get the list of references.
Fixed the code to format an git_oid into a Hex String
Fixed the example ls_remote
Updated ecf include location header for Linux.
Updated generator.sh to use Linux path of libgit2 headers,